### PR TITLE
fix compatibility for 0.12.1

### DIFF
--- a/layers.py
+++ b/layers.py
@@ -58,7 +58,7 @@ def conv2d(inputs, num_outputs, kernel_size, stride,
       inputs, num_outputs, kernel_size,
       stride, activation_fn=activation_fn, 
       weights_initializer=weights_initializer,
-      biases_initializer=tf.zeros_initializer(dtype=tf.float32), scope=scope, **kargv)
+      biases_initializer=tf.zeros_initializer, scope=scope, **kargv)
   if name:
     scope = "{}/{}".format(name, scope)
   _update_dict(layer_dict, scope, outputs)


### PR DESCRIPTION
zeros_initializer was called as a function, which is in fact incompatible with 0.12.1

I am new to tensorflow, so this fix may be incorrect.